### PR TITLE
Fix default charset for operating systems which dont use UTF-8

### DIFF
--- a/src/riveted/core.clj
+++ b/src/riveted/core.clj
@@ -114,7 +114,7 @@
     (navigator \"<root xmlns:ns=\\\"http://example.com/ns\\\"><foo>Bar</foo></root>\" true)"
   ([^String xml] (navigator xml false))
   ([^String xml namespace-aware]
-   (let [vg (doto (VTDGen.) (.setDoc (.getBytes xml))
+   (let [vg (doto (VTDGen.) (.setDoc (.getBytes xml "UTF-8"))
                             (.parse namespace-aware))]
      (Navigator. (.getNav vg)))))
 


### PR DESCRIPTION
.getBytes uses systems charset if not suplied charset via parameter. For XML reading one must give UTF-8 charset as a parameter. This is necessary for systems which doesnt use UTF-8 as a system charset (for example Windows).