### PR TITLE
Add API to generate a navigator from a byte array

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ passing it a UTF-8 encoded string of XML and then storing the result in the
 (def nav (vtd/navigator (slurp "foo.xml")))
 ```
 
+If you already have your XML in a byte array, you can pass this directly to `navigator` instead of a UTF-8 string:
+
+```clojure
+(def nav (vtd/navigator my-byte-array))
+```
+
 `navigator` also takes an optional second argument to enable XML namespace
 support which is disabled by default. We'll look at this
 [later](#namespace-support) but, for now, we can process this document without
@@ -410,6 +416,9 @@ metadata.
 
 Thanks to [Heikki Hämäläinen](https://github.com/hjhamala) for contributing a
 character encoding fix for Windows users.
+
+Thanks to [Eugen Stan](https://github.com/ieugen) for suggesting that
+`navigator` should also accept byte arrays as well as UTF-8 strings.
 
 ## License
 

--- a/test/riveted/core_test.clj
+++ b/test/riveted/core_test.clj
@@ -17,6 +17,16 @@
 (defn tags? [& tag-names] (fn [actual] (= tag-names (map tag actual))))
 (def root? (tag? "root"))
 
+(fact "navigator returns a VTD navigator for a byte array."
+  (navigator (.getBytes "<a></a>" "UTF-8")) => nav?
+  (navigator (.getBytes "<a></a>" "ISO-8859-1")) => nav?)
+
+(fact "navigator returns a VTD navigator for a UTF-8 string."
+  (navigator "<a></a>") => nav?)
+
+(fact "navigator raises an IllegalArgumentException nil if given nil."
+  (navigator nil) => (throws IllegalArgumentException))
+
 (fact "search returns a sequence of matching navigators for a given XPath."
   (search nav "/root/basic-title") => (one-of nav?)
   (search nav "//i") => (two-of nav?)


### PR DESCRIPTION
As raised by @ieugen, the underlying VTDGen API allows generating a navigator from a byte array. We previously only permitted navigators to be generated from UTF-8 strings which were then internally converted to bytes. We can skip this needless conversion for users that already have their XML in byte arrays by allowing the navigator function to accept them directly.
